### PR TITLE
Fix Simple Analytics link

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -58,7 +58,7 @@ const today = new Date();
             >
         </button>
         <a
-            href="https://simpleanalytics.com/joeduncko.com?utm_source=joeduncko.com"
+            href="https://dashboard.simpleanalytics.com/joeduncko.com"
             class="m-1 hover:text-[#3668c7]"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
## Summary
- update footer Simple Analytics link to the dashboard URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276a7d5a5c832aa9f65958b88e4f4a)