### PR TITLE
Fix code block styling in blog posts

### DIFF
--- a/src/layouts/markdown-styles.module.css
+++ b/src/layouts/markdown-styles.module.css
@@ -96,7 +96,7 @@
     margin-bottom: 0.5rem;
 }
 
-.markdown code {
+.markdown :not(pre) > code {
     background-color: #f9f9f9;
     border: 1px solid #e1e4e8;
     font-family: "Courier New", Courier, monospace;
@@ -104,6 +104,10 @@
     padding: 0.2em 0.4em;
     border-radius: 3px;
     box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.markdown pre code {
+    font-family: "Courier New", Courier, monospace;
 }
 
 /* For nested lists */


### PR DESCRIPTION
## Summary
- scope custom code styling to inline snippets so fenced code blocks keep their syntax highlighting
- keep code block font settings without overriding shiki-provided colors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a864265d8832a9e2af199a470aad2)